### PR TITLE
Removing the master and slave lingo

### DIFF
--- a/apitest/test/ApiCases/api/datacenter/test_table.py
+++ b/apitest/test/ApiCases/api/datacenter/test_table.py
@@ -44,20 +44,20 @@ class CalTest(unittest.TestCase):
            平台应用场景：获取这个表在数据中心所配的所有主表
         '''
         nowlogin = Login().login('admin')  # 登录系统
-        sendrequest = nowlogin.get(Login().url + '/api/datacenter/table/master/dfcong')
+        sendrequest = nowlogin.get(Login().url + '/api/datacenter/table/main/dfcong')
         outputrequest(sendrequest,os.path.abspath(__file__),sys._getframe().f_code.co_name)  # 输出请求方式和请求API到report中
         self.assertEqual(True, isJson(jsonstr=sendrequest), msg='判断返回值是否为json格式')  # 断言(判断返回值是否为json格式)
         self.assertEqual(200, sendrequest.json()['status'], msg='【status】获取这个表在数据中心所配的所有主表')  # # 断言(检查返回值status)
         self.assertEqual('DF主', sendrequest.json()['result']['dfzhu']['title'],
                          msg='【response】获取这个表在数据中心所配的所有主表')  # 断言(检查返回值response)
 
-    def test_getslaveTable(self):
+    def test_getsubordinateTable(self):
         '''获取这个表在数据中心所配的所有从表
            应用访问地址：数据中心
            平台应用场景：获取这个表在数据中心所配的所有从表
         '''
         nowlogin = Login().login('admin')  # 登录系统
-        sendrequest = nowlogin.get(Login().url + '/api/datacenter/table/slave/dfzhu')
+        sendrequest = nowlogin.get(Login().url + '/api/datacenter/table/subordinate/dfzhu')
         outputrequest(sendrequest,os.path.abspath(__file__),sys._getframe().f_code.co_name)  # 输出请求方式和请求API到report中
         self.assertEqual(True, isJson(jsonstr=sendrequest), msg='判断返回值是否为json格式')  # 断言(判断返回值是否为json格式)
         self.assertEqual('DF从', sendrequest.json()['dfcong']['title'],

--- a/apitest/test/ApiCases/api/information/test_data.py
+++ b/apitest/test/ApiCases/api/information/test_data.py
@@ -17,8 +17,8 @@ class CalTest(unittest.TestCase):
         values = {'params[data][0][name]': 'dfcong_congzifuchuan',
                   'params[data][0][value]': '从表添加保存',
                   'params[appId]': 'DFCongBiaoTianJiaQua',
-                  'params[master][tableId]': 'dfzhu',
-                  'params[master][recordId]': 1
+                  'params[main][tableId]': 'dfzhu',
+                  'params[main][recordId]': 1
                   }
         nowlogin = Login().login('dulei')  # 登录系统
         sendrequest = nowlogin.post(Login().url + '/api/information/data/dfcong/', data=values)
@@ -130,7 +130,7 @@ class CalTest(unittest.TestCase):
            平台应用场景：流程从表导出
         '''
         params={
-            'params':'{"masterTableId":"wfmain","masterRecordId":"3","appId":"QuanZiDuanLiuCheng","type":"workflow","records":["2"]}'
+            'params':'{"mainTableId":"wfmain","mainRecordId":"3","appId":"QuanZiDuanLiuCheng","type":"workflow","records":["2"]}'
         }
         nowlogin = Login().login('admin')  # 登录系统
         sendrequest = nowlogin.get(

--- a/apitest/test/ApiCases/api2/data/workflow/test_deleteslave.py
+++ b/apitest/test/ApiCases/api2/data/workflow/test_deleteslave.py
@@ -17,11 +17,11 @@ class CalTest(unittest.TestCase):
             'workflowId': 'YiDongDuanZhuCong',
             'instanceId': 49,
             'nodeId': 'WorkNode_1',
-            'slaveId': 'yidongduanzhucongco',
+            'subordinateId': 'yidongduanzhucongco',
             'id': 3
         }
         nowlogin = Login().login('admin')  # 登录系统
-        sendrequest = nowlogin.delete(Login().url + '/api2/data/workflow/deleteslave', params=params)
+        sendrequest = nowlogin.delete(Login().url + '/api2/data/workflow/deletesubordinate', params=params)
         outputrequest(sendrequest,os.path.abspath(__file__),sys._getframe().f_code.co_name)  # 输出请求方式和请求API到report中
         self.assertEqual(True, isJson(jsonstr=sendrequest), msg='判断返回值是否为json格式')  # 断言(判断返回值是否为json格式)
         self.assertEqual(1200, sendrequest.json()['status'], msg='【status】APP流程从表记录删除')  # 断言(检查返回值status是否为200)

--- a/apitest/test/ApiCases/api2/data/workflow/test_editslave.py
+++ b/apitest/test/ApiCases/api2/data/workflow/test_editslave.py
@@ -18,9 +18,9 @@ class CalTest(unittest.TestCase):
             'instanceId': 49,
             'nodeId': 'WorkNode_1',
             'workflowId': 'YiDongDuanZhuCong',
-            'slave_id': 'yidongduanzhucongco',
-            'data': '{"slaveId":"yidongduanzhucongco","slaveKeyColumn":"","slaveName":"移动端主从-从表",'
-                    '"slave_item_fields":[{"schema":{"basic":"","belongs":"","controlledFields":"","created_time":"",'
+            'subordinate_id': 'yidongduanzhucongco',
+            'data': '{"subordinateId":"yidongduanzhucongco","subordinateKeyColumn":"","subordinateName":"移动端主从-从表",'
+                    '"subordinate_item_fields":[{"schema":{"basic":"","belongs":"","controlledFields":"","created_time":"",'
                     '"creator":"","datasource":"","expression":"","expression_fields":"","formIndex":"","id":"id",'
                     '"index":"","last_modified":"","mainField":"","metadata":"","modifier":"","relationControlFields":"",'
                     '"relationMapFields":"","relationSearchFields":"","report":"","required":"","systemTime":"","title":"",'
@@ -62,10 +62,10 @@ class CalTest(unittest.TestCase):
                     '"required":"","systemTime":"","title":"","type":"","unique":""},"table_id":"","table_title":"","table_type":"",'
                     '"value":{"access_button":"","access_changeable":true,"access_deleteable":false,"access_readable":true,"id":"",'
                     '"last_modified":"","modified_method":"workflow/YiDongDuanZhuCong/49/WorkNode_1","modifier":"","owner":"",'
-                    '"value":"编辑从表记录新"},"workProviderType":"STRING"}],"slave_item_id":"1"}'
+                    '"value":"编辑从表记录新"},"workProviderType":"STRING"}],"subordinate_item_id":"1"}'
         }
         nowlogin = Login().login('admin')  # 登录系统
-        sendrequest = nowlogin.put(Login().url + '/api2/data/workflow/editslave', data=values)
+        sendrequest = nowlogin.put(Login().url + '/api2/data/workflow/editsubordinate', data=values)
         outputrequest(sendrequest,os.path.abspath(__file__),sys._getframe().f_code.co_name)  # 输出请求方式和请求API到report中
         self.assertEqual(True, isJson(jsonstr=sendrequest), msg='判断返回值是否为json格式')  # 断言(判断返回值是否为json格式)
         self.assertEqual(1200, sendrequest.json()['status'], msg='【status】APP流程从表记录编辑')  # 断言(检查返回值status是否为1200)

--- a/apitest/test/ApiCases/api2/data/workflow/test_getnodeslavelist.py
+++ b/apitest/test/ApiCases/api2/data/workflow/test_getnodeslavelist.py
@@ -19,12 +19,12 @@ class CalTest(unittest.TestCase):
             'instanceId': 49,
             'nodeId': 'WorkNode_1',
             'todoNodeId': 'WorkNode_1',
-            'slaveId': 'yidongduanzhucongco',
+            'subordinateId': 'yidongduanzhucongco',
             'paging[start]': 0,
             '&paging[perPage]': 15
         }
         nowlogin = Login().login('admin')  # 登录系统
-        sendrequest = nowlogin.get(Login().url + '/api2/data/workflow/getnodeslavelist', params=params)
+        sendrequest = nowlogin.get(Login().url + '/api2/data/workflow/getnodesubordinatelist', params=params)
         outputrequest(sendrequest,os.path.abspath(__file__),sys._getframe().f_code.co_name)  # 输出请求方式和请求API到report中
         self.assertEqual(True, isJson(jsonstr=sendrequest), msg='判断返回值是否为json格式')  # 断言(判断返回值是否为json格式)
         self.assertEqual(1200, sendrequest.json()['status'], msg='【status】APP获取流程从表记录')  # 断言(检查返回值status是否为200)

--- a/apitest/test/ApiCases/api2/data/workflow/test_getslavefields.py
+++ b/apitest/test/ApiCases/api2/data/workflow/test_getslavefields.py
@@ -19,10 +19,10 @@ class CalTest(unittest.TestCase):
             'workflowId': 'QuanZiDuanLiuCheng',
             'instanceId': 16,
             'nodeId': 'WorkNode_1',
-            'slaveId': 'wfsub01'
+            'subordinateId': 'wfsub01'
         }
         nowlogin = Login().login('admin')  # 登录系统
-        sendrequest = nowlogin.get(Login().url + '/api2/data/workflow/getslavefields', params=params)
+        sendrequest = nowlogin.get(Login().url + '/api2/data/workflow/getsubordinatefields', params=params)
         outputrequest(sendrequest,os.path.abspath(__file__),sys._getframe().f_code.co_name)  # 输出请求方式和请求API到report中
         self.assertEqual(True, isJson(jsonstr=sendrequest), msg='判断返回值是否为json格式')  # 断言(判断返回值是否为json格式)
         self.assertEqual(1200, sendrequest.json()['status'], msg='【status】APP获取流程从表结构')

--- a/apitest/test/ApiCases/api2/data/workflow/test_submitmaster.py
+++ b/apitest/test/ApiCases/api2/data/workflow/test_submitmaster.py
@@ -8,20 +8,20 @@ from apitest.test.method.checkmethod import isJson, outputrequest
 
 
 class CalTest(unittest.TestCase):
-    def test_submitmaster(self):
+    def test_submitmain(self):
         '''APP流程——从表添加权限验证(主表无添加权限)
            应用访问地址：/app/!/workflow/GongZuoXieTong
            工作标题：流程从表添加权限用例
            平台应用场景：工作协同
         '''
         values = {'instanceId': 10085,
-                  'slaveTableId': 'gongzuoshouli',
+                  'subordinateTableId': 'gongzuoshouli',
                   'nodeId': 'WorkNode_4',
                   'workflowId': 'GongZuoXieTong',
                   'data': '[]'
                   }
         nowlogin = Login().login('dulei')  # 登录系统
-        sendrequest = nowlogin.post(Login().url + '/api2/data/workflow/submitmaster', data=values)
+        sendrequest = nowlogin.post(Login().url + '/api2/data/workflow/submitmain', data=values)
         outputrequest(sendrequest,os.path.abspath(__file__),sys._getframe().f_code.co_name)  # 输出请求方式和请求API到report中
         expect = 1200  # 期望返回值
         self.assertEqual(True, isJson(jsonstr=sendrequest), msg='判断返回值是否为json格式')  # 断言

--- a/apitest/test/ApiCases/api2/data/workflow/test_submitnode.py
+++ b/apitest/test/ApiCases/api2/data/workflow/test_submitnode.py
@@ -44,7 +44,7 @@ class CalTest(unittest.TestCase):
                                                         r'\"needAssign\":false,\"Label\":\"委托审核\"}}","node_id":"WorkNode_1","node_name":"委托填写",'
                                                         r'"node_next_user":[{"AssignedMethods":"manual","AssignedTo":[{"Type":"member","id":"UIDdulei","parent_id":"7",'
                                                         r'"name":["产品测试组","组员","杜磊"],"type":"member","parent":"7","Parent":"7"}],"isDraft":true,'
-                                                        r'"node_id":"WorkNode_2","node_name":"委托审核","workflow_id":"WeiTuoYongLiYi"}],"slaves":[],'
+                                                        r'"node_id":"WorkNode_2","node_name":"委托审核","workflow_id":"WeiTuoYongLiYi"}],"subordinates":[],'
                                                         r'"users":[{"user_id":"ApiTest","user_name":"企业管理员"}],"workflow_id":"WeiTuoYongLiYi"}'
         }
         sendrequest = nowlogin.post(Login().url + '/api2/data/workflow/submitnode', data=values)

--- a/apitest/test/ApiCases/api2/data/workflow/test_submitslave.py
+++ b/apitest/test/ApiCases/api2/data/workflow/test_submitslave.py
@@ -18,9 +18,9 @@ class CalTest(unittest.TestCase):
             'instanceId': 50,
             'nodeId': 'WorkNode_1',
             'workflowId': 'YiDongDuanZhuCong',
-            'slave_id': 'yidongduanzhucongco',
-            'data': r'{"slaveId":"yidongduanzhucongco","slaveKeyColumn":"","slaveName":"移动端主从-从表",'
-                    r'"slave_item_fields":[{"schema":{"basic":"0","belongs":"yidongduanzhucongco",'
+            'subordinate_id': 'yidongduanzhucongco',
+            'data': r'{"subordinateId":"yidongduanzhucongco","subordinateKeyColumn":"","subordinateName":"移动端主从-从表",'
+                    r'"subordinate_item_fields":[{"schema":{"basic":"0","belongs":"yidongduanzhucongco",'
                     r'"controlledFields":"{\"required_rule\":[],\"unchangeable_rule\":[],\"displayable_rule\":[]}",'
                     r'"created_time":"2017-03-09 11:13:12","creator":"ApiTest","datasource":"","expression":"0",'
                     r'"expression_fields":"[]","formIndex":"","id":"id","index":"1","last_modified":"2017-03-09 11:13:12",'
@@ -75,7 +75,7 @@ class CalTest(unittest.TestCase):
                     r'"value":"从表新增测试"},"workProviderType":"STRING"}]}'
         }
         nowlogin = Login().login('admin')  # 登录系统
-        sendrequest = nowlogin.post(Login().url + '/api2/data/workflow/submitslave', data=values)
+        sendrequest = nowlogin.post(Login().url + '/api2/data/workflow/submitsubordinate', data=values)
         outputrequest(sendrequest,os.path.abspath(__file__),sys._getframe().f_code.co_name)  # 输出请求方式和请求API到report中
         self.assertEqual(True, isJson(jsonstr=sendrequest), msg='判断返回值是否为json格式')  # 断言(判断返回值是否为json格式)
         self.assertEqual(1200, sendrequest.json()['status'], msg='【status】APP流程新增从表记录')

--- a/apitest/test/ApiCases/api2/uiengine/test_table.py
+++ b/apitest/test/ApiCases/api2/uiengine/test_table.py
@@ -8,13 +8,13 @@ from apitest.test.method.checkmethod import isJson, outputrequest
 
 
 class CalTest(unittest.TestCase):
-    def test_Master(self):
+    def test_Main(self):
         '''获取应用主表
            应用访问地址：/app/!/information/DFMoRenPeiZhiHanCong
            平台应用场景：DF、WF自定义筛选入口进入时触发
         '''
         nowlogin = Login().login('admin')  # 登录系统
-        sendrequest = nowlogin.get(Login().url + '/api2/uiengine/table/master/information/DFMoRenPeiZhiHanCong/0')
+        sendrequest = nowlogin.get(Login().url + '/api2/uiengine/table/main/information/DFMoRenPeiZhiHanCong/0')
         outputrequest(sendrequest,os.path.abspath(__file__),sys._getframe().f_code.co_name)  # 输出请求方式和请求API到report中
         self.assertEqual(True, isJson(jsonstr=sendrequest), msg='判断返回值是否为json格式')  # 断言(判断返回值是否为json格式)
         self.assertEqual(200, sendrequest.json()['status'], msg='【status】获取应用主表')
@@ -89,10 +89,10 @@ class CalTest(unittest.TestCase):
            平台应用场景：默认视图——>表单配置——>保存
         '''
         values = {
-            'params': '{"master":{"tableId":"uiyinqingzhubiao"},"extend":[{"tableId":"uiyinqingcongbiao",'
+            'params': '{"main":{"tableId":"uiyinqingzhubiao"},"extend":[{"tableId":"uiyinqingcongbiao",'
                       '"condition":{"display":[],"required":[],"displayType":"AND"},'
                       '"fields":[{"title":"从表字符串","table":"uiyinqingcongbiao","field":"congbiaozifuchuan"}],'
-                      '"type":"slave","magnifierConfig":[]},{"tableId":"uiyinqingziyingyongy",'
+                      '"type":"subordinate","magnifierConfig":[]},{"tableId":"uiyinqingziyingyongy",'
                       '"condition":{"display":[],"required":[],"displayType":"AND"},'
                       '"fields":[{"title":"子应用字段","table":"uiyinqingziyingyongy",'
                       '"field":"ziyingyongziduan"}],"type":"subapp","magnifierConfig":[]}],"magnifierConfig":[],"documents":{"word":[],"export":[]}}'
@@ -104,7 +104,7 @@ class CalTest(unittest.TestCase):
         self.assertEqual(True, isJson(jsonstr=sendrequest), msg='判断返回值是否为json格式')  # 断言(判断返回值是否为json格式)
         self.assertEqual(200, sendrequest.json()['status'], msg='【status】表单配置保存')
 
-    def test_SaveMaster(self):
+    def test_SaveMain(self):
         '''业务表设计新增表单(workflow:主表绑定)
            应用访问地址：/app/edit?id=162&type=workflow#!/step_2/WFYeWuBiaoXinZengBia/39
            平台应用场景：默认视图——>业务表设计——>选择表
@@ -113,7 +113,7 @@ class CalTest(unittest.TestCase):
         values = {
             'params[extra]': 'uiyinqingzhubiao',
             'params[table]': 'uiyinqingzhubiao',
-            'params[type]': 'master'
+            'params[type]': 'main'
         }
         nowlogin = Login().login('admin')  # 登录系统
         sendrequest = nowlogin.post(Login().url + '/api2/uiengine/table/workflow/WFYeWuBiaoXinZengBia/39',

--- a/apitest/test/ApiCases/api2/workflow/test_instance_node_datacenter.py
+++ b/apitest/test/ApiCases/api2/workflow/test_instance_node_datacenter.py
@@ -40,7 +40,7 @@ class CalTest(unittest.TestCase):
             'targetId': 0,
             'scId': 0,
             'params[appId]': 'GongZuoXieTong',
-            'params[slaveTableId]': 'gongzuoshouli',
+            'params[subordinateTableId]': 'gongzuoshouli',
             'params[paging][perPage]': 15,
             'params[paging][start]': 0,
             'params[condition]': '',
@@ -70,8 +70,8 @@ class CalTest(unittest.TestCase):
                     r'{"name":"wfsub01_sub01duoxuan","value":["B"]},{"name":"wfsub01_sub01fujian","value":[]},'
                     r'{"name":"wfsub01_sub01riqishijian","value":"2018-04-27 14:04:02"},'
                     r'{"name":"wfsub01_sub01zuzhijiagou","value":"{\"displayValue\":\"  云平台研发部  \",\"real\":{\"orgs\":{\"2\":{\"id\":\"2\",\"parent_id\":\"12\",\"Type\":\"department\"}},\"blacklist\":{}}}"}]',
-            'master_table_id': 'wfmain',
-            'master_record_id': 2
+            'main_table_id': 'wfmain',
+            'main_record_id': 2
         }
         nowlogin = Login().login('admin')  # 登录系统
         sendrequest = nowlogin.post(


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.